### PR TITLE
fix id number of table in index.blade.php

### DIFF
--- a/modules/Cyaxaress/Category/Resources/Views/index.blade.php
+++ b/modules/Cyaxaress/Category/Resources/Views/index.blade.php
@@ -20,7 +20,7 @@
                     <tbody>
                     @foreach($categories as $category)
                     <tr role="row" class="">
-                        <td><a href="">{{ $category->id }}</a></td>
+                        <td><a href="" >{{ $loop->index+1 }}</a></td>
                         <td><a href="">{{ $category->title }}</a></td>
                         <td>{{ $category->slug }}</td>
                         <td>{{ $category->parent }}</td>


### PR DESCRIPTION
hi hemn 

when we use $category->id, if we remove any record from database, the order of numbers will not be correct any more.
when we use  $loop->index+1, if we delete any record from database, the order of numbers will not be wrong anymore